### PR TITLE
Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: default
+default: hugo-dev-server
+
+.PHONY: hugo-dev-server
+hugo-dev-server:
+	hugo server
+
+.PHONY: hugo-build-prod
+hugo-build-prod:
+	hugo --minify -b $(url)
+
+.PHONY: build-prod
+build-prod: hugo-build-prod
+
+
+.PHONY: hugo-build-dev
+hugo-build-dev:
+	hugo
+
+.PHONY: build-dev
+build-dev: hugo-build-dev
+
+
+.PHONY: clean
+clean:
+	rm -rd public/
+	rm -rd resources/

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ default: hugo-dev-server
 
 .PHONY: hugo-dev-server
 hugo-dev-server:
-	hugo server
+	hugo server --ignoreCache --disableFastRender
 
 .PHONY: hugo-build-prod
 hugo-build-prod:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,32 @@
 ﻿# www-hugo
 The source code for Hugo version of certain websites at fri.uni-lj.si available at https://nejchirci.github.io/ with
 laboratory page at https://nejchirci.github.io/lab/ and personal page at https://nejchirci.github.io/employees/ .
+
+
+## Development
+### Dependencies
+* [Hugo](https://gohugo.io/)
+* [GNU Make](https://www.gnu.org/software/make/)
+
+### Commands
+#### Local development server
+```bash
+make
+```
+
+#### Builds
+##### Development
+```bash
+make build-dev
+```
+
+##### Production
+```bash
+# Replace "http://example.com" with the base url of the site
+make build-prod url=http://example.com 
+```
+
+#### Other
+```bash
+make clean  # run after "make build-dev" or "make build-prod"
+```

--- a/runHugo.sh
+++ b/runHugo.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-# Build the project.
-hugo server --ignoreCache --disableFastRender
-# if using a theme, replace with `hugo -t <YOURTHEME>`


### PR DESCRIPTION
As projects get bigger it's better practice to use Makefiles instead of custom built scripts.

Here is a good brief intro into [Makefiles](https://matthias-endler.de/2017/makefiles/), if not familiar.

Now to run Hugo's built in dev server, simply run:
```bash
make
```

It's common for GNU Make to be installed on machines (GNU/Linux or macOS) since it's a very common dependency. So issuing `make` shouldn't pose problems.